### PR TITLE
Add "node" to .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,7 @@
   "immed": true,
   "jquery": true,
   "noarg": true,
+  "node":true,
   "onevar": true,
   "quotmark": "double",
   "smarttabs": true,


### PR DESCRIPTION
Required to prevent various "is not defined" errors.